### PR TITLE
feat: admin deletion overrides

### DIFF
--- a/db/postgres/postgres_shared_testing.go
+++ b/db/postgres/postgres_shared_testing.go
@@ -21,6 +21,7 @@ func TESTONLY_SetupAndCleanup(t *testing.T) *PostgresDB {
 	pg.db.Exec(`DROP TABLE IF EXISTS edges CASCADE`)
 	pg.db.Exec(`DROP TABLE IF EXISTS node_edits CASCADE`)
 	pg.db.Exec(`DROP TABLE IF EXISTS nodes CASCADE`)
+	pg.db.Exec(`DROP TABLE IF EXISTS roles CASCADE`)
 	pgdb, err = NewPostgresDB(TESTONLY_Config)
 	assert.NoError(err)
 	pg = pgdb.(*PostgresDB)


### PR DESCRIPTION
- add "roles" table
- if a role "admin" is present for a user, that user may delete any edge, and any node (that has no edges)

edit: this currently means soft-deletion, and cascading soft-deletion, i.e.:
```
learngraph=# select * from nodes where id = 19;
 id |          created_at          |          updated_at           | deleted_at |     description     |      resources
----+------------------------------+-------------------------------+------------+---------------------+----------------------
 19 | 2024-03-13 15:31:08.75373+00 | 2024-03-13 15:32:23.883218+00 |            | {"en": "newthing3"} | {"en": "there!\n\n"}
(1 row)

learngraph=# select * from nodes where id = 19;
 id |          created_at          |          updated_at           |          deleted_at           |     description     |      resources
----+------------------------------+-------------------------------+-------------------------------+---------------------+----------------------
 19 | 2024-03-13 15:31:08.75373+00 | 2024-03-13 15:32:23.883218+00 | 2024-03-13 15:39:10.579334+00 | {"en": "newthing3"} | {"en": "there!\n\n"}
(1 row)

learngraph=# select * from node_edits where node_id = 19;
 id  |          created_at           |          updated_at           |          deleted_at           | node_id | user_id |  type  |   new_description   | new_resources
-----+-------------------------------+-------------------------------+-------------------------------+---------+---------+--------+---------------------+---------------
 266 | 2024-03-13 15:31:08.780707+00 | 2024-03-13 15:31:08.780707+00 | 2024-03-13 15:39:10.579627+00 |      19 |      31 | create | {"en": "newthing3"} | {}
 267 | 2024-03-13 15:32:23.883617+00 | 2024-03-13 15:32:23.883617+00 | 2024-03-13 15:39:10.579627+00 |      19 |      31 | edit   | {"en": "newthing3"} |
(2 rows)
```